### PR TITLE
Fix void-function org-export--prepare-file-contents error

### DIFF
--- a/org-glossary.el
+++ b/org-glossary.el
@@ -400,6 +400,7 @@ The PATH-SPEC is formed with respect to the current buffer."
 (defun org-glossary--include-once (parameters)
   "Include content based on PARAMETERS."
   (unless (eq (plist-get parameters :env) 'literal)
+    (require 'ox)
     (let ((lines (plist-get parameters :lines))
           (file (plist-get parameters :file))
           (location (plist-get parameters :location))


### PR DESCRIPTION
`org-glossary--include-once` calls `org-export--prepare-file-contents`, which is defined in `ox`, but `ox` is not loaded.

This happens because `org-export--prepare-file-contents` (defined in
`ox`) is called in `org-glossary--include-once`, which will be called when `org-glossary-mode` is activated, having been given an external source to look up terms in. E.g.

```elisp
(setq org-glossary-global-terms (list "~/path/to/glossary.org"))
(add-hook 'org-mode-hook #'org-glossary-mode)
```

I decided to load `ox` from `org-export--prepare-file-contents` rather than top-level, because all other uses of `ox`'s API are autoloaded, and I'm a fan of lazy-loading.