### PR TITLE
feat: enhance keybinding setup for org-glossary

### DIFF
--- a/org-glossary.el
+++ b/org-glossary.el
@@ -1809,21 +1809,28 @@ This should only be run as an export hook."
      (0 (org-glossary--fontify-term))))
   "`font-lock-keywords' entry that fontifies term references.")
 
+(defvar org-glossary-keymap
+  (make-sparse-keymap)
+  "Keymap for mouse actions over fontified Denote links.")
+
+(defun org-glossary-setup-keymap ()
+  "Set up the `org-glossary-keymap' with default bindings."
+  (interactive)
+  (define-key org-glossary-keymap [mouse-1] #'org-glossary-goto-term-definition)
+  (define-key org-glossary-keymap [mouse-2] #'org-glossary-goto-term-definition)
+  (define-key org-glossary-keymap [follow-link] #'org-glossary-goto-term-definition))
+
 (defun org-glossary--set-font-lock-keywords (&optional per-term-p)
   "Set `org-glossary--font-lock-keywords' according to PER-TERM-P."
   (setq org-glossary--font-lock-keywords
         (if per-term-p
             '((org-glossary--fontify-find-next
                (0 (org-glossary--fontify-term))))
-          '((org-glossary--fontify-find-next
-             (0 '(face org-glossary-term
+          `((org-glossary--fontify-find-next
+             (0 `(face org-glossary-term
                   help-echo org-glossary--help-echo-from-textprop
                   mouse-face (:inverse-video t)
-                  keymap (keymap
-                          (follow-link . mouse-face)
-                          (mouse-2 . org-glossary-goto-term-definition)
-                          ("RET" . org-glossary-goto-term-definition)
-                          (return . org-glossary-goto-term-definition)))
+                  keymap ,org-glossary-keymap)
                 t)))))
   per-term-p)
 
@@ -1931,11 +1938,7 @@ This should only be run as an export hook."
       `(help-echo
         org-glossary--help-echo-from-textprop
         mouse-face (:inverse-video t)
-        keymap (keymap
-                (follow-link . mouse-face)
-                (mouse-2 . org-glossary-goto-term-definition)
-                ("RET" . org-glossary-goto-term-definition)
-                (return . org-glossary-goto-term-definition)))))))
+        keymap ,org-glossary-keymap)))))
 
 (defvar-local org-glossary--help-echo-cache (make-hash-table :test #'equal)
   "A hash table for quickly looking up fontified help-echo strings.")

--- a/org-glossary.org
+++ b/org-glossary.org
@@ -16,6 +16,11 @@ in-buffer highlighting of defined terms and high-quality exports across all =ox-
 backends.
 
 ** Quickstart
+Install =org-glossary= with your favourite package manager, e.g. =use-package=.  To set up the default keybindings, run ~(org-glossary-setup-keymap)~.  Alternatively, you can setup your own key-bindings e.g. using:
+
+#+begin_src emacs-lisp
+  (define-key org-glossary-keymap (kbd "C-c C-c") 'org-glossary-goto-term-definition)
+#+end_src
 
 To define a glossary entry, simply place a top-level heading in the document
 titled =Glossary= or =Acronyms= and therein define terms using an Org definition


### PR DESCRIPTION
- Introduced `org-glossary-keymap` to centralize keybinding management.
- Added `org-glossary-setup-keymap` function to setup default mouse bindings.
- Updated `org-glossary.el` to utilize the new keymap instead of inline keymaps.
- Included documentation in `org-glossary.org` on setting up key maps with custom bindings.

This update simplifies keybinding customization for users and enhances maintainability by consolidating keymap definitions.